### PR TITLE
Use sass-extract for standard sass type conversion to json

### DIFF
--- a/packages/sass-export-data/package.json
+++ b/packages/sass-export-data/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@theme-tools/core": "^1.0.0",
-    "jsondiffpatch": "^0.2.5"
+    "jsondiffpatch": "^0.2.5",
+    "sass-extract": "^1.0.1"
   }
 }

--- a/packages/sass-export-data/readme.md
+++ b/packages/sass-export-data/readme.md
@@ -13,7 +13,7 @@ npm install --save @theme-tools/sass-export-data
 ```js
 const config = {
   name: 'export_data', // Name of Sass function
-  path: 'path/to/export/folder/' // Folder where to place JSON files
+  path: 'path/to/export/folder/', // Folder where to place JSON files
 };
 const sassExportData = require('@theme-tools/sass-export-data')(config);
 ```
@@ -30,10 +30,10 @@ In your sass declare this mixin to make it easier:
 /// @param $var - What to turn into JSON
 /// @example scss
 ///   @include export-data-to-lib('filename.json', $sass-map);
-@mixin export-data($filename, $var) {
+@mixin export-data($filename, $var, $options: ()) {
   // The `export_data` function is a custom function added to Sass.
   // The `$data` var is weird, but needed.
-  $data: export_data($filename, $var);
+  $data: export_data($filename, $var, $options);
 };
 ```
 
@@ -52,8 +52,27 @@ This will create the file `example.json` in `path/to/export/folder/` with:
 
 ```json
 {
-  "a": "Apple",
-  "b": "Beer"
+  "sass-export-data": {
+    "a": "Apple",
+    "b": "Beer"
+  }
+}
+```
+
+To change the `root` key in the output JSON, send over a third argument as a SassMap:
+
+```scss
+@include export-data('example.json', $x, (root: 'myNewRoot'));
+```
+
+Resulting in:
+
+```json
+{
+  "myNewRoot": {
+    "a": "Apple",
+    "b": "Beer"
+  }
 }
 ```
 


### PR DESCRIPTION
This PR changes the shape of the output JSON, thus probably requiring a bump on the version of `sass-export-data` to 2.0.0. It does a few things:

1. Simply uses a lib off of [sass-extract](https://github.com/jgranstrom/sass-extract/blob/master/src/struct.js) for consistent conversion of all Sass types.
1. Makes a root key required on the output JSON. This defaults to `sass-export-data` but is easily overridden by using the mixin with a third argument Map (see update to README.md for details)

Note: this uses ES6 object destructuring syntax, which is supported by Node 6+.

Output json now has the sass-extract format, which converts this map:

```scss
(
scssColors: (
  "primary":    $primary,
  "secondary":  $secondary,
  "success":    $success,
  "info":       $info,
  "warning":    $warning,
  "danger":     $danger,
  "light":      $light,
  "dark":       $dark
),
test: 20rem
)
```

into:

```json
{
  "sass-export-data": {
    "type": "SassMap",
    "value": {
      "scssColors": {
        "type": "SassMap",
        "value": {
          "primary": {
            "type": "SassColor",
            "value": {
              "r": 0,
              "g": 123,
              "b": 255,
              "a": 1,
              "hex": "#007bff"
            }
          },
          "secondary": {
            "type": "SassColor",
            "value": {
              "r": 134,
              "g": 142,
              "b": 150,
              "a": 1,
              "hex": "#868e96"
            }
          },
          "success": {
            "type": "SassColor",
            "value": {
              "r": 40,
              "g": 167,
              "b": 69,
              "a": 1,
              "hex": "#28a745"
            }
          },
          "info": {
            "type": "SassColor",
            "value": {
              "r": 23,
              "g": 162,
              "b": 184,
              "a": 1,
              "hex": "#17a2b8"
            }
          },
          "warning": {
            "type": "SassColor",
            "value": {
              "r": 255,
              "g": 193,
              "b": 7,
              "a": 1,
              "hex": "#ffc107"
            }
          },
          "danger": {
            "type": "SassColor",
            "value": {
              "r": 220,
              "g": 53,
              "b": 69,
              "a": 1,
              "hex": "#dc3545"
            }
          },
          "light": {
            "type": "SassColor",
            "value": {
              "r": 248,
              "g": 249,
              "b": 250,
              "a": 1,
              "hex": "#f8f9fa"
            }
          },
          "dark": {
            "type": "SassColor",
            "value": {
              "r": 52,
              "g": 58,
              "b": 64,
              "a": 1,
              "hex": "#343a40"
            }
          },
          "test": {
            "type": "SassColor",
            "value": {
              "r": 255,
              "g": 192,
              "b": 203,
              "a": 1,
              "hex": "#ffc0cb"
            }
          },
          "herp": {
            "type": "SassColor",
            "value": {
              "r": 128,
              "g": 0,
              "b": 128,
              "a": 1,
              "hex": "#800080"
            }
          },
          "derp": {
            "type": "SassColor",
            "value": {
              "r": 255,
              "g": 165,
              "b": 0,
              "a": 1,
              "hex": "#ffa500"
            }
          }
        }
      },
      "test": {
        "type": "SassNumber",
        "value": 20,
        "unit": "rem"
      }
    }
  }
}
```