### PR TITLE
Make sass-export-data compatible with dart sass 1.50

### DIFF
--- a/packages/sass-export-data/sass-export-data.js
+++ b/packages/sass-export-data/sass-export-data.js
@@ -15,18 +15,21 @@ module.exports = (userConfig) => {
     let i;
     switch (a.constructor.name) {
       case 'SassList':
+      case 'sass.types.List':
         value = [];
         for (i = 0; i < a.getLength(); i++) {
           value.push(getValue(a.getValue(i)));
         }
         break;
       case 'SassMap':
+      case 'sass.types.Map':
         value = {};
         for (i = 0; i < a.getLength(); i++) {
           value[a.getKey(i).getValue()] = getValue(a.getValue(i));
         }
         break;
       case 'SassColor':
+      case 'sass.types.Color':
         if (a.getA() === 1) {
           value = `rgb(${Math.round(a.getR())}, ${Math.round(a.getG())}, ${Math.round(a.getB())})`;
         } else {
@@ -34,6 +37,7 @@ module.exports = (userConfig) => {
         }
         break;
       case 'SassNumber':
+      case 'sass.types.Number':
         value = a.getValue();
         if (a.getUnit()) {
           value += a.getUnit();


### PR DESCRIPTION
The "sass-export-data" package has been working just fine with dart-sass (`sass`) up until recent versions (1.50), when they have apparently changed the classes for their variables, so the constructor names are different. This pull request restores the compatibility with dart-sass (`sass`) by adding the new constructor names to the old (`node-sass` and older `sass`) ones.